### PR TITLE
Parse short forms of versions and parse garbage as Invalid versions.

### DIFF
--- a/src/main/scala/parse.scala
+++ b/src/main/scala/parse.scala
@@ -1,7 +1,6 @@
 package semverfi
 
 import scala.util.parsing.combinator.RegexParsers
-import java.io.Reader
 
 object Parse extends RegexParsers {
 
@@ -59,8 +58,15 @@ object Parse extends RegexParsers {
   def classifier: Parser[Seq[String]] =
     Dash ~> ids
 
-  def apply(in: String) = parseAll(version, in) match {
-    case Success(result, _) => result
-    case failure : NoSuccess => Invalid(in)
+  def apply(in: String) = {
+    try {
+      parseAll(version, in) match {
+        case Success(result, _) => result
+        case failure : NoSuccess => Invalid(in)
+      }
+    } catch {
+      case e: NullPointerException => Invalid(in)
+    }
   }
+  
 }

--- a/src/main/scala/parse.scala
+++ b/src/main/scala/parse.scala
@@ -1,6 +1,7 @@
 package semverfi
 
 import scala.util.parsing.combinator.RegexParsers
+import java.io.Reader
 
 object Parse extends RegexParsers {
 
@@ -10,11 +11,13 @@ object Parse extends RegexParsers {
 
   private val Dash = "-"
 
-  def id: Parser[String] = """[0-9A-Za-z-]+""".r
+  val id: Parser[String] = """[0-9A-Za-z-]+""".r
 
-  def int: Parser[String] = """\d+""".r
+  val int: Parser[String] = """\d+""".r
 
-  def version: Parser[SemVersion] =
+  val anything: Parser[String] = """[0-9A-Za-z\.\-\_\+]+""".r
+
+  val version: Parser[SemVersion] =
     buildVersion | preReleaseVersion | normalVersion
 
   def buildVersion: Parser[BuildVersion] =
@@ -42,6 +45,12 @@ object Parse extends RegexParsers {
     int ~ (Dot ~> int) ~ (Dot ~> int) ^^ {
       case (maj ~ min ~ pat) =>
         (maj.toInt, min.toInt, pat.toInt)
+  } | int ~ (Dot ~> int) ^^ {
+      case (maj ~ min) =>
+        (maj.toInt, min.toInt, 0)
+  } | int ^^ {
+      case (maj) =>
+        (maj.toInt, 0, 0)
   }
 
   def ids: Parser[Seq[String]] =
@@ -50,6 +59,8 @@ object Parse extends RegexParsers {
   def classifier: Parser[Seq[String]] =
     Dash ~> ids
 
-  def apply(in: String) =
-    parseAll(version, in)
+  def apply(in: String) = parseAll(version, in) match {
+    case Success(result, _) => result
+    case failure : NoSuccess => Invalid(in)
+  }
 }

--- a/src/main/scala/semver.scala
+++ b/src/main/scala/semver.scala
@@ -1,11 +1,7 @@
 package semverfi
 
 object Version {
-  def apply(in: String): SemVersion =
-     Parse(in) match {
-      case Parse.Success(v, _) => v
-      case _ => Invalid(in)
-    }
+  def apply(in: String): SemVersion = Parse(in)
 }
 
 sealed trait SemVersion extends SemVersionOrdering {

--- a/src/test/scala/order.scala
+++ b/src/test/scala/order.scala
@@ -31,4 +31,20 @@ object OrderSpec extends Specification {
                                                               Seq("alpha"))
     }
   }
+  "specific examples" should {
+    "order 2.1 after 1.2.1" in {
+      val v1 = Version("1.2.1")
+      val v2 = Version("2.1")
+      v1 must beLessThan(v2)
+      v2 must beGreaterThan(v1)
+      v1 must_!= v2
+    }
+    "order 2 after 1.2.1" in {
+      val v1 = Version("1.2.1")
+      val v2 = Version("2")
+      v1 must beLessThan(v2)
+      v2 must beGreaterThan(v1)
+      v1 must_!= v2
+    }
+  }
 }

--- a/src/test/scala/parse.scala
+++ b/src/test/scala/parse.scala
@@ -4,34 +4,29 @@ import org.specs._
 
 object ParseSpec extends Specification {
   "semver parse" should {
-    "not parse garbage" in {
-      Parse("1.0.0a").isInstanceOf[Parse.Failure] must be(true)
+    "parse 'garbage' as invalid version" in {
+      Parse("1.0.0a") must_== Invalid("1.0.0a")
     }
     "parse normal versions" in {
-      Parse("0.1.0") match {
-        case Parse.Success(r, _) => r must_== NormalVersion(0,1,0)
-        case a => fail("unexpected parse result %s" format a)
-      }
+      Parse("0.1.0") must_== NormalVersion(0,1,0)
     }
     "parse pre-release versions" in {
-      Parse("0.1.1-alpha.1") match {
-        case Parse.Success(r, _) =>
-            r must_== PreReleaseVersion(0, 1, 1, Seq("alpha","1"))
-        case a => fail("unexpected parse result %s" format a)
-      }
+      Parse("0.1.1-alpha.1") must_== PreReleaseVersion(0, 1, 1, Seq("alpha","1"))
     }
     "parse build versions with classifiers" in {
-      Parse("0.1.1-alpha.1+a") match {
-        case Parse.Success(r , _) =>
-            r must_== BuildVersion(0, 1, 1, Seq("alpha", "1"), Seq("a"))
-        case a => fail("unexpected parse result %s" format a)
-      }
+      Parse("0.1.1-alpha.1+a") must_== BuildVersion(0, 1, 1, Seq("alpha", "1"), Seq("a"))
     }
     "parse build versions without classifiers" in {
-      Parse("0.1.1+a") match {
-        case Parse.Success(r, _) => r must_== BuildVersion(0, 1, 1, Nil, Seq("a"))
-        case a => fail("unexpected parse result %s" format a)
-      }
+      Parse("0.1.1+a") must_== BuildVersion(0, 1, 1, Nil, Seq("a"))
+    }
+    "parse invalid version" in {
+      Parse("2.4+Problem_case") must_== Invalid("2.4+Problem_case")
+    }
+    "parse short form version" in {
+      Parse("2.1") must_== NormalVersion(2,1,0)
+    }
+    "parse very short form version" in {
+      Parse("2") must_== NormalVersion(2,0,0)
     }
   }
 }


### PR DESCRIPTION
Currently versions like "1" and "1.0" are considered to be invalid versions so they are parsed but not ordered 'correctly'.  To be strict to the Semver standard it would appear that versions should always be of the form X.Y.Z but, at least from my viewpoint, this library would be more intuitive if it parsed them as if they were "X.0.0" or "X.Y.0".

This patch makes that change and also treats any 'garbage' as an `Invalid` version and parses it without throwing an error.
